### PR TITLE
Add redhat 9 vars file

### DIFF
--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,16 @@
+---
+mariadb_login_unix_socket: "/var/lib/mysql/mysql.sock"
+mariadb_pre_req_packages:
+  - "python3-mysqlclient"
+mariadb_packages:
+  - "MariaDB-server"
+  - "galera-4"
+mariabackup_packages:
+  - "MariaDB-backup"
+mariadb_certificates_dir: "/etc/my.cnf.d/certificates"
+mariadb_systemd_service_name: "mysql.service"
+mariadb_confs:
+  - name: "etc/my.cnf.d/server.cnf"
+mariadb_temp_confs:
+  - "etc/my.cnf.d/server.cnf"
+galera_wsrep_provider: "/usr/lib64/galera-4/libgalera_smm.so"


### PR DESCRIPTION
Addresses the change for mariadb_pre_req_packages from "MySQL-python" to "python3-mysqlclient"